### PR TITLE
Update systemd detection assumptions

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -15,18 +15,10 @@ end
 
 package 'nzbdrone'
 
-case node['platform']
-when 'ubuntu'
-  if node['platform_version'].to_f >= 15.04
-    template '/etc/systemd/system/sonarr.service' do
-      source 'sonarr.service.erb'
-      variables user: node[:sonarr][:user]
-  end
-  elsif node['platform_version'].to_f >= 12.04
-    template '/etc/init/sonarr.conf' do
-      source 'init.conf.erb'
-      variables user: node[:sonarr][:user]
-    end
+if system('pidof systemd')
+  template '/etc/systemd/system/sonarr.service' do
+    source 'sonarr.service.erb'
+    variables user: node[:sonarr][:user]
   end
 else
   template '/etc/init/sonarr.conf' do


### PR DESCRIPTION
Update service configuration template to more accurately determine whether systemd should be used or not.

This recipe was giving me guff on my Debian system because it relies on systemd to manage services, but the fallback configs were being setup because it didn't pass any of the platform conditionals. This update should more robustly handle different systems that work utilize systemd. Curious to get any thoughts/suggestions on this solution to my woes.